### PR TITLE
Allow empty config

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -19,7 +19,7 @@ class Provider extends ServiceProvider
         ], 'money');
 
         Money::setLocale($this->app->make('translator')->getLocale());
-        Currency::setCurrencies($this->app->make('config')->get('money'));
+        Currency::setCurrencies($this->app->make('config')->get('money') ?: []);
 
         // Register blade directives
         $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {


### PR DESCRIPTION
As a follow-up from https://github.com/akaunting/laravel-money/issues/40

When installing the package while the config is cached, the call to `$this->app->make('config')->get('money')` returns null. This in turn generates errors because the definition of `setCurrencies` expects an array. This completely breaks the Laravel installation until the user realises they need to delete the cached config file using `rm bootstrap/cache/config.php`

By allowing empty cache (sending an empty array instead), this gives the user a chance to install the module and then cache the config again without errors all over their screen.