### PR TITLE
Set Croatian Kuna symbol_first to false

### DIFF
--- a/src/Config/money.php
+++ b/src/Config/money.php
@@ -646,7 +646,7 @@ return [
         'precision'           => 2,
         'subunit'             => 100,
         'symbol'              => 'kn',
-        'symbol_first'        => true,
+        'symbol_first'        => false,
         'decimal_mark'        => ',',
         'thousands_separator' => '.',
     ],


### PR DESCRIPTION
You can see [here on Croatian National Bank website](https://www.hnb.hr/en/currency/banknotes) we put `kuna` (shortened: `kn`) after the amount.