### PR TITLE
Add #[ReturnTypeWillChange] attribute to suppress deprecation warning…

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -866,6 +866,8 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
      *
      * @return array
      */
+    
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
…s and fatal error

Fatal error on composer install or composer update. ie: composer update or composer create-project akaunting/akaunting
Illuminate\Foundation\ComposerScripts::postAutoloadDump PHP Fatal error:  During inheritance of JsonSerializable: Uncaught ErrorException: Return type of Akaunting\Money\Money::jsonSerialize()

Error occurs on php 7.4 >=