### PR TITLE
src/Currency.php Add #[ReturnTypeWillChange] attribute to suppress deprecation warning…

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -480,6 +480,8 @@ class Currency implements Arrayable, Jsonable, JsonSerializable, Renderable
      *
      * @return array
      */
+    
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
…s and fatal error

Fatal error on composer install or composer update. ie: composer update or composer create-project akaunting/akaunting
Illuminate\Foundation\ComposerScripts::postAutoloadDump PHP Fatal error:  During inheritance of JsonSerializable: Uncaught ErrorException: Return type of Akaunting\Money\Currency::jsonSerialize()

Error occurs on php 7.4 >=