### PR TITLE
Fix BBD symbol position

### DIFF
--- a/src/Config/money.php
+++ b/src/Config/money.php
@@ -129,7 +129,7 @@ return [
         'precision'           => 2,
         'subunit'             => 100,
         'symbol'              => '$',
-        'symbol_first'        => false,
+        'symbol_first'        => true,
         'decimal_mark'        => '.',
         'thousands_separator' => ',',
     ],


### PR DESCRIPTION
In Barbados (BBD) the symbol comes first. This fixes that issue.