### PR TITLE
Update blade directives registration

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -4,6 +4,7 @@ namespace Akaunting\Money;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+
 class Provider extends ServiceProvider
 {
     /**

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -44,11 +44,11 @@ class Provider extends ServiceProvider
         }
 
         Blade::directive('money', function ($expression) {
-            return "<?php money($expression); ?>";
+            return "<?php echo money($expression); ?>";
         });
 
         Blade::directive('currency', function ($expression) {
-            return "<?php currency($expression); ?>";
+            return "<?php echo currency($expression); ?>";
         });
 
         return $this;

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -4,8 +4,6 @@ namespace Akaunting\Money;
 
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\Compilers\BladeCompiler;
-
 class Provider extends ServiceProvider
 {
     /**
@@ -38,20 +36,21 @@ class Provider extends ServiceProvider
         $this->loadViewsFrom(__DIR__ . '/Resources/views', 'money');
     }
 
-    public function registerBladeDirectives()
+    protected function registerBladeDirectives(): self
     {
-        // Register blade directives
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
-            $bladeCompiler->directive('money', function ($expression) {
-                return "<?php echo money($expression); ?>";
-            });
+        if (! $this->app->has('blade.compiler')) {
+            return $this;
+        }
+
+        Blade::directive('money', function ($expression) {
+            return "<?php money($expression); ?>";
         });
 
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
-            $bladeCompiler->directive('currency', function ($expression) {
-                return "<?php echo currency($expression); ?>";
-            });
+        Blade::directive('currency', function ($expression) {
+            return "<?php currency($expression); ?>";
         });
+
+        return $this;
     }
 
     public function registerBladeComponents()


### PR DESCRIPTION
Came across an issue where the directives are all rendered as strings. After searching in recent changes came to the conclusion that https://github.com/spatie/laravel-ray has caused this. 

Seems like https://github.com/spatie/laravel-ray/blob/main/src/RayServiceProvider.php#L226 uses a much cleaner method to check if the blade.compiler is resolved then my previous fix in [PR](https://github.com/akaunting/laravel-money/pull/4).