### PR TITLE
Added default setting for conversion, and currency directive now respects default currency

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,11 +4,16 @@ use Akaunting\Money\Currency;
 use Akaunting\Money\Money;
 
 if (!function_exists('money')) {
-    function money(mixed $amount, string $currency = null, bool $convert = false): Money
+    function money(mixed $amount, string $currency = null, bool $convert = null): Money
     {
         if (is_null($currency)) {
             /** @var string $currency */
             $currency = env('DEFAULT_CURRENCY', 'USD');
+        }
+        
+        if (is_null($convert)) {
+            /** @var bool $currency */
+            $convert = env('CONVERT_CURRENCY_DEFAULT', false);
         }
 
         return new Money($amount, currency($currency), $convert);
@@ -16,8 +21,13 @@ if (!function_exists('money')) {
 }
 
 if (!function_exists('currency')) {
-    function currency(string $currency): Currency
+    function currency(string $currency = null): Currency
     {
+        if (is_null($currency)) {
+            /** @var string $currency */
+            $currency = env('DEFAULT_CURRENCY', 'USD');
+        }
+        
         return new Currency($currency);
     }
 }


### PR DESCRIPTION
I'm working on a project that would really benefit from setting a default value for currency conversion, as well as from the `@currency` directive also respecting the default currency setting.

We currently store values as decimals already, and we only support one global currency. It's a lot less work to just be able to mindlessly use `@currency` and `@money` and not worry about anything else.

As such I would like you to consider these changes and pull them into the repository.