### PR TITLE
currencies or array

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -22,7 +22,8 @@ class Provider extends ServiceProvider
         ], 'money');
 
         Money::setLocale($this->app->make('translator')->getLocale());
-        Currency::setCurrencies($this->app->make('config')->get('money'));
+        $currencies = $this->app->make('config')->get('money');
+        Currency::setCurrencies($currencies ?? []);
 
         $this->registerBladeDirectives();
         $this->registerBladeComponents();


### PR DESCRIPTION
When package is installed and if laravel config is cached the app throws an exception because the currencies returns null.