### PR TITLE
fix: Use config for defaults

### DIFF
--- a/config/money.php
+++ b/config/money.php
@@ -2,6 +2,10 @@
 
 return [
 
+    'defaults' => [
+        'currency' => env('DEFAULT_CURRENCY', 'USD'),
+    ],
+
     'AED' => [
         'name'                => 'UAE Dirham',
         'code'                => 784,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,7 +8,7 @@ if (!function_exists('money')) {
     {
         if (is_null($currency)) {
             /** @var string $currency */
-            $currency = env('DEFAULT_CURRENCY', 'USD');
+            $currency = config('money.defaults.currency');
         }
 
         return new Money($amount, currency($currency), $convert);


### PR DESCRIPTION
`env()` should never be used outside of config files, as it returns `null` if the config files are cached.