### PR TITLE
Make Currency & Money Macroable

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -182,8 +182,8 @@ use OutOfBoundsException;
  */
 class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
-	use Macroable;
-	
+    use Macroable;
+    
     protected string $currency;
 
     protected string $name;

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\Macroable;
 use JsonSerializable;
 use OutOfBoundsException;
 
@@ -181,6 +182,8 @@ use OutOfBoundsException;
  */
 class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
+	use Macroable;
+	
     protected string $currency;
 
     protected string $name;

--- a/src/Money.php
+++ b/src/Money.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Support\Traits\Macroable;
 use InvalidArgumentException;
 use JsonSerializable;
 use OutOfBoundsException;
@@ -185,6 +186,8 @@ use OutOfBoundsException;
  */
 class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
+	use Macroable;
+	
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
 
     const ROUND_HALF_DOWN = PHP_ROUND_HALF_DOWN;

--- a/src/Money.php
+++ b/src/Money.php
@@ -186,8 +186,8 @@ use OutOfBoundsException;
  */
 class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
-	use Macroable;
-	
+    use Macroable;
+    
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
 
     const ROUND_HALF_DOWN = PHP_ROUND_HALF_DOWN;


### PR DESCRIPTION
This PR adds the `Illuminate\Support\Traits\Macroable` to the package. As there's currently no option to implement our own custom formatters, this would allow us to add a custom method for a specific format (e.g. `->formatMollie()`). 

Thanks!