### PR TITLE
Use new static instead of new self

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -208,7 +208,7 @@ class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Rende
      *
      * @throws OutOfBoundsException
      */
-    public function __construct(string $currency)
+    final public function __construct(string $currency)
     {
         $currency = strtoupper(trim($currency));
         $currencies = static::getCurrencies();

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -232,7 +232,7 @@ class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Rende
 
     public static function __callStatic(string $method, array $arguments): Currency
     {
-        return new self($method);
+        return new static($method);
     }
 
     /**

--- a/src/Money.php
+++ b/src/Money.php
@@ -282,7 +282,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
     {
         $convert = isset($arguments[1]) && is_bool($arguments[1]) && $arguments[1];
 
-        return new self($arguments[0], new Currency($method), $convert);
+        return new static($arguments[0], new Currency($method), $convert);
     }
 
     /**
@@ -430,7 +430,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         $amount = $this->round($this->amount + $addend, $roundingMode);
 
         if ($this->isImmutable()) {
-            return new self($amount, $this->currency);
+            return new static($amount, $this->currency);
         }
 
         $this->amount = $amount;
@@ -449,7 +449,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         $amount = $this->round($this->amount - $subtrahend, $roundingMode);
 
         if ($this->isImmutable()) {
-            return new self($amount, $this->currency);
+            return new static($amount, $this->currency);
         }
 
         $this->amount = $amount;
@@ -462,7 +462,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         $amount = $this->round($this->amount * $multiplier, $roundingMode);
 
         if ($this->isImmutable()) {
-            return new self($amount, $this->currency);
+            return new static($amount, $this->currency);
         }
 
         $this->amount = $amount;
@@ -477,7 +477,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         $amount = $this->round($this->amount / $divisor, $roundingMode);
 
         if ($this->isImmutable()) {
-            return new self($amount, $this->currency);
+            return new static($amount, $this->currency);
         }
 
         $this->amount = $amount;
@@ -503,7 +503,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
 
         foreach ($ratios as $ratio) {
             $share = floor($this->amount * $ratio / $total);
-            $results[] = new self($share, $this->currency);
+            $results[] = new static($share, $this->currency);
             $remainder -= $share;
         }
 
@@ -658,7 +658,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
     {
         $this->mutable = false;
 
-        return new self($this->amount, $this->currency);
+        return new static($this->amount, $this->currency);
     }
 
     public function mutable(): Money

--- a/src/Money.php
+++ b/src/Money.php
@@ -206,7 +206,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
      *
      * @throws UnexpectedAmountException
      */
-    public function __construct(mixed $amount, Currency $currency, bool $convert = false)
+    final public function __construct(mixed $amount, Currency $currency, bool $convert = false)
     {
         $this->currency = $currency;
         $this->amount = $this->parseAmount($amount, $convert);
@@ -278,7 +278,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $amount * $this->currency->getSubunit();
     }
 
-    public static function __callStatic(string $method, array $arguments): Money
+    public static function __callStatic(string $method, array $arguments): static
     {
         $convert = isset($arguments[1]) && is_bool($arguments[1]) && $arguments[1];
 
@@ -412,14 +412,14 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $this->compare($other) <= 0;
     }
 
-    public function convert(Currency $currency, int|float $ratio, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function convert(Currency $currency, int|float $ratio, int $roundingMode = self::ROUND_HALF_UP): static
     {
         $this->currency = $currency;
 
         return $this->multiply($ratio, $roundingMode);
     }
 
-    public function add(int|float|Money $addend, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function add(int|float|Money $addend, int $roundingMode = self::ROUND_HALF_UP): static
     {
         if ($addend instanceof Money) {
             $this->assertSameCurrency($addend);
@@ -438,7 +438,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $this;
     }
 
-    public function subtract(int|float|Money $subtrahend, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function subtract(int|float|Money $subtrahend, int $roundingMode = self::ROUND_HALF_UP): static
     {
         if ($subtrahend instanceof Money) {
             $this->assertSameCurrency($subtrahend);
@@ -457,7 +457,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $this;
     }
 
-    public function multiply(int|float $multiplier, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function multiply(int|float $multiplier, int $roundingMode = self::ROUND_HALF_UP): static
     {
         $amount = $this->round($this->amount * $multiplier, $roundingMode);
 
@@ -470,7 +470,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $this;
     }
 
-    public function divide(int|float $divisor, int $roundingMode = self::ROUND_HALF_UP): Money
+    public function divide(int|float $divisor, int $roundingMode = self::ROUND_HALF_UP): static
     {
         $this->assertDivisor($divisor);
 
@@ -654,14 +654,14 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return $this->format();
     }
 
-    public function immutable(): Money
+    public function immutable(): static
     {
         $this->mutable = false;
 
         return new static($this->amount, $this->currency);
     }
 
-    public function mutable(): Money
+    public function mutable(): static
     {
         $this->mutable = true;
 


### PR DESCRIPTION
This PR ensures that we are using "new static" everywhere instead of "new self". This would allow developers to extend the Money and/or Currency classes and add methods of their own.

Thanks!