### PR TITLE
Using defaultCurrency from the config file

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,7 +8,7 @@ if (!function_exists('money')) {
     {
         if (is_null($currency)) {
             /** @var string $currency */
-            $currency = env('DEFAULT_CURRENCY', 'USD');
+            $currency = config('money.defaultCurrency', 'USD');
         }
 
         return new Money($amount, currency($currency), $convert);


### PR DESCRIPTION
Since #72 might not the merged, maybe you can merge this PR?

Right now it's not possible to use the @money-blade-helper-function with "defaultCurrency" set in the money.php config-file. My suggestion is using "defaultCurrency" from the config-file for the Blade-helper.