### PR TITLE
Change return type of jsonSerialize 

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -650,7 +650,7 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
         return json_encode($this->toArray(), $options);
     }
 
-    public function jsonSerialize(): array
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
The `JsonSerializable::jsonSerialize` returns `mixed` instead of `array`

this should fix the error:
> PHP message: PHP Deprecated:  Return type of Akaunting\Money\Money::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed

PHP version: 8.1.2