### PR TITLE
#87 - Allow static macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,76 @@ or
 <x-currency currency="USD" />
 ```
 
+### Macros
+
+This package implements the Laravel `Macroable` trait, allowing macros and mixins on both `Money` and `Currency`.
+
+Example use case:
+
+```php
+use Akaunting\Money\Currency;
+use Akaunting\Money\Money;
+
+Money::macro(
+    'absolute',
+    fn () => $this->isPositive() ? $this : $this->multiply(-1)
+);
+
+$money = Money::USD(1000)->multiply(-1);
+
+$absolute = $money->absolute();
+```
+
+Macros can be called statically too:
+
+```php
+use Akaunting\Money\Currency;
+use Akaunting\Money\Money;
+
+Money::macro('zero', fn (?string $currency = null) => new Money(0, new Currency($currency ?? 'GBP')));
+
+$money = Money::zero();
+```
+
+### Mixins
+
+Along with Macros, Mixins are also supported. This allows merging another classes methods into the Money or Currency class.
+
+Define the mixin class:
+
+```php
+use Akaunting\Money\Money;
+
+class CustomMoney 
+{
+    public function absolute(): Money
+    {
+        return $this->isPositive() ? $this : $this->multiply(-1);
+    }
+    
+    public static function zero(?string $currency = null): Money
+    {
+        return new Money(0, new Currency($currency ?? 'GBP'));
+    }
+}
+```
+
+Register the mixin, by passing an instance of the class:
+
+```php
+Money::mixin(new CustomMoney);
+```
+
+The methods from the custom class will be available:
+
+```php
+$money = Money::USD(1000)->multiply(-1);
+$absolute = $money->absolute();
+
+// Static methods via mixins are supported too:
+$money = Money::zero();
+```
+
 ## Changelog
 
 Please see [Releases](../../releases) for more information on what has changed recently.

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -182,7 +182,9 @@ use OutOfBoundsException;
  */
 class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
-    use Macroable;
+    use Macroable {
+        __callStatic as protected macroableCallStatic;
+    }
 
     protected string $currency;
 
@@ -235,6 +237,10 @@ class Currency implements Arrayable, Castable, Jsonable, JsonSerializable, Rende
 
     public static function __callStatic(string $method, array $arguments): Currency
     {
+        if (static::hasMacro($method)) {
+            return static::macroableCallStatic($method, $arguments);
+        }
+
         return new self($method);
     }
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -186,7 +186,9 @@ use OutOfBoundsException;
  */
 class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderable
 {
-    use Macroable;
+    use Macroable {
+        __callStatic as protected macroableCallStatic;
+    }
 
     const ROUND_HALF_UP = PHP_ROUND_HALF_UP;
 
@@ -283,6 +285,10 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
 
     public static function __callStatic(string $method, array $arguments): Money
     {
+        if (static::hasMacro($method)) {
+            return static::macroableCallStatic($method, $arguments);
+        }
+
         $convert = isset($arguments[1]) && is_bool($arguments[1]) && $arguments[1];
 
         return new self($arguments[0], new Currency($method), $convert);

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -88,4 +88,11 @@ class CurrencyTest extends TestCase
         $this->assertEmpty(Currency::getCurrencies());
         Currency::setCurrencies($currencies);
     }
+
+    public function testStaticMacro()
+    {
+        Currency::macro('testMacro', fn () => Currency::EUR());
+
+        $this->assertEquals(Currency::EUR(), Currency::testMacro());
+    }
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -411,4 +411,11 @@ class MoneyTest extends TestCase
         $this->assertTrue($money->isImmutable());
         $this->assertFalse($money->mutable()->isImmutable());
     }
+
+    public function testStaticMacro()
+    {
+        Money::macro('testMacro', fn () => Money::USD(1099));
+
+        $this->assertEquals(Money::USD(1099), Money::testMacro());
+    }
 }


### PR DESCRIPTION
Fixes: #87 

Money and Currency override the Macroable `__callStatic` method, effectively disabling static macros.

To resolve this issue, a check has been added: If the statically called method exists as a macro, then call the macro instead.


Additionally, added Macros and Mixins to the README - currently this functionality is not documented.

Tests:
<img width="601" alt="Screenshot 2023-07-20 at 21 43 19" src="https://github.com/akaunting/laravel-money/assets/35956374/3d6cfbc1-7209-4ae4-9f20-8897db436dfb">

Example usage:

```php
use Akaunting\Money\Currency;
use Akaunting\Money\Money;

Money::macro(
    'zero', 
    fn (?string $currency = null) => new Money(0, new Currency($currency ?? 'GBP'))
);

$money = Money::zero();
```