### PR TITLE
Set Georgian Lari unicode character instead of letter L

### DIFF
--- a/config/money.php
+++ b/config/money.php
@@ -556,7 +556,7 @@ return [
             'code'                => 981,
             'precision'           => 2,
             'subunit'             => 100,
-            'symbol'              => 'ლ',
+            'symbol'              => '₾',
             'symbol_first'        => false,
             'decimal_mark'        => '.',
             'thousands_separator' => ',',

--- a/config/money.php
+++ b/config/money.php
@@ -557,7 +557,7 @@ return [
             'precision'           => 2,
             'subunit'             => 100,
             'symbol'              => '₾',
-            'symbol_first'        => false,
+            'symbol_first'        => true,
             'decimal_mark'        => '.',
             'thousands_separator' => ',',
         ],


### PR DESCRIPTION
Current symbol is set to "ლ" (same as `ლ`, just looks different in monospace). It is just the first letter of `ლარი` - the currency name in Georgian.

Since Unicode v8.0 (June 2015) there is special symbol for Lari in unicode "₾" that could be used for this purpose.

Reference/proof: https://en.wikipedia.org/wiki/Georgian_lari