### PR TITLE
Fixing Currency Conversion Glitch: Ensuring Accuracy and Precision

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -505,6 +505,11 @@ class Money implements Arrayable, Castable, Jsonable, JsonSerializable, Renderab
     public function round(int|float $amount, int $mode = self::ROUND_HALF_UP): float
     {
         $this->assertRoundingMode($mode);
+        
+        if ($this->currency->getSubunit() == 1){
+
+            return round($amount, 0 ,$mode);
+        }
 
         return round($amount, $this->currency->getPrecision(), $mode);
     }


### PR DESCRIPTION

Encountering a conversion rate below 0.9 from the source currency to the target currency, along with the absence of cents in the currency, can be quite tricky during conversion. This unexpected shift of the decimal point to the left by two places isn't something we want happening! So, I'm stepping in with a pull request to fix this issue. It's all about making sure currency conversion is smooth and accurate for everyone involved!

For instance, 2,525,600 yen converted at a rate of 0.031 should indeed give you around 77,778.38 in MYR, but it seems to be returning 777.78 instead