### PR TITLE
Update Blade component to accept currency objects

### DIFF
--- a/src/View/Components/Money.php
+++ b/src/View/Components/Money.php
@@ -2,6 +2,7 @@
 
 namespace Akaunting\Money\View\Components;
 
+use Akaunting\Money\Currency;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
@@ -10,10 +11,12 @@ class Money extends Component
 {
     public function __construct(
         public mixed $amount,
-        public ?string $currency = null,
+        public null|string|Currency $currency = null,
         public ?bool $convert = null
     ) {
-        //
+        if ($currency instanceof Currency) {
+            $this->currency = $currency->getCurrency();
+        }
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,7 @@ use Akaunting\Money\Currency;
 use Akaunting\Money\Money;
 
 if (! function_exists('money')) {
-    function money(mixed $amount, string $currency = null, bool $convert = null): Money
+    function money(mixed $amount, string|Currency $currency = null, bool $convert = null): Money
     {
         if (is_null($currency)) {
             /** @var string $currency */
@@ -21,11 +21,15 @@ if (! function_exists('money')) {
 }
 
 if (! function_exists('currency')) {
-    function currency(string $currency = null): Currency
+    function currency(string|Currency $currency = null): Currency
     {
         if (is_null($currency)) {
             /** @var string $currency */
             $currency = config('money.defaults.currency');
+        }
+
+        if ($currency instanceof Currency) {
+            return $currency;
         }
 
         return new Currency($currency);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -19,4 +19,10 @@ class HelpersTest extends TestCase
         $this->assertEquals(new Currency('USD'), currency('USD'));
         $this->assertEquals(new Currency('TRY'), currency('TRY'));
     }
+
+    public function testCurrencyAcceptsCurrencyObject()
+    {
+        $this->assertEquals(new Currency('USD'), currency(new Currency('USD')));
+        $this->assertEquals(new Currency('TRY'), currency(new Currency('TRY')));
+    }
 }

--- a/tests/View/Components/MoneyTest.php
+++ b/tests/View/Components/MoneyTest.php
@@ -20,17 +20,6 @@ class MoneyTest extends TestCase
 
     public function testRenderingWithCurrencyObject()
     {
-        $this->component(Money::class, [
-            'amount' => 1000,
-            'currency' => Currency::GBP(),
-        ])->assertSee('£10.00');
-
-        $this->component(Money::class, [
-            'amount' => 1000,
-            'currency' => Currency::GBP(),
-            'convert' => true,
-        ])->assertSee('£1,000.00');
-
         $this->blade('<x-money amount="1000" :currency="\Akaunting\Money\Currency::GBP()" />')->assertSee('£10.00');
         $this->blade('<x-money amount="1000" :currency="\Akaunting\Money\Currency::GBP()" convert />')->assertSee('£1,000.00');
     }

--- a/tests/View/Components/MoneyTest.php
+++ b/tests/View/Components/MoneyTest.php
@@ -2,7 +2,9 @@
 
 namespace Akaunting\Money\Tests\View\Components;
 
+use Akaunting\Money\Currency;
 use Akaunting\Money\Tests\TestCase;
+use Akaunting\Money\View\Components\Money;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 
 class MoneyTest extends TestCase
@@ -14,5 +16,19 @@ class MoneyTest extends TestCase
         $this->blade('<x-money amount="1000" />')->assertSee('$10.00');
         $this->blade('<x-money amount="1000" convert />')->assertSee('$1,000.00');
         $this->blade('<x-money amount="1000" currency="GBP" convert />')->assertSee('£1,000.00');
+    }
+
+    public function testRenderingWithCurrencyObject()
+    {
+        $this->component(Money::class, [
+            'amount' => 1000,
+            'currency' => Currency::GBP(),
+        ])->assertSee('£10.00');
+
+        $this->component(Money::class, [
+            'amount' => 1000,
+            'currency' => Currency::GBP(),
+            'convert' => true,
+        ])->assertSee('£1,000.00');
     }
 }

--- a/tests/View/Components/MoneyTest.php
+++ b/tests/View/Components/MoneyTest.php
@@ -30,5 +30,8 @@ class MoneyTest extends TestCase
             'currency' => Currency::GBP(),
             'convert' => true,
         ])->assertSee('£1,000.00');
+
+        $this->blade('<x-money amount="1000" :currency="\Akaunting\Money\Currency::GBP()" />')->assertSee('£10.00');
+        $this->blade('<x-money amount="1000" :currency="\Akaunting\Money\Currency::GBP()" convert />')->assertSee('£1,000.00');
     }
 }


### PR DESCRIPTION
This change enables app templates to be shorter.

```blade
$currency = \Akaunting\Money\Currency::GBP();

// Before this PR, this template would throw an error:
<x-money amount="1000" :currency="$currency" />

// One would have to do this:
<x-money amount="1000" :currency="$currency->getCurrency()" />
```

Now it works. It's no longer a requirement to pass the 3-character string of the currency.