### PR TITLE
fix: use the explicit nullable type

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,7 +4,7 @@ use Akaunting\Money\Currency;
 use Akaunting\Money\Money;
 
 if (! function_exists('money')) {
-    function money(mixed $amount, string $currency = null, bool $convert = null): Money
+    function money(mixed $amount, ?string $currency = null, bool $convert = null): Money
     {
         if (is_null($currency)) {
             /** @var string $currency */
@@ -21,7 +21,7 @@ if (! function_exists('money')) {
 }
 
 if (! function_exists('currency')) {
-    function currency(string $currency = null): Currency
+    function currency(?string $currency = null): Currency
     {
         if (is_null($currency)) {
             /** @var string $currency */


### PR DESCRIPTION
use the explicit nullable type `?string` to avoid Implicitly marking parameters as nullable which is now deprecated in PHP 8.4+